### PR TITLE
Add missing semicolon for italic Tahoma fallback

### DIFF
--- a/examples/open-sans.html
+++ b/examples/open-sans.html
@@ -28,7 +28,7 @@
 	<div class="fallback-examples">
 		<p style="font-family: 'Open Sans', sans-serif; font-style: italic;">Open Sans Italic</p>
 		<p style="font-family: 'Segoe UI', sans-serif; font-style: italic;">Segoe UI Italic (Windows Only)</p>
-		<p style="font-family: Tahoma, sans-serif font-style: italic;">Tahoma Italic</p>
+		<p style="font-family: Tahoma, sans-serif; font-style: italic;">Tahoma Italic</p>
 	</div>
 	<div class="fallback-examples">
 		<p style="font-family: 'Open Sans', sans-serif; font-weight: bold;">Open Sans Bold</p>


### PR DESCRIPTION
### Motivation

I was searching for some appropriate fallback fonts for Open Sans, in doing so stumbled across this site. I noticed the italic font style was not applying.

### Change 
Add the missing semicolon so that the `font-style` will correctly apply to the Tahoma example.

Thanks for putting this together all those years ago. 🙂 